### PR TITLE
Check options before trying to work on them

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ Changelog
 1.0.7 (unreleased)
 ------------------
 
+- Check options before trying to work on them
+  [ale-rt]
+
 - Use "application/javascript" media type instead of the obsolete "text/javascript".
   [hvelarde]
 

--- a/plone4/csrffixes/protect.js
+++ b/plone4/csrffixes/protect.js
@@ -12,6 +12,9 @@ if(script){
   if(window.jQuery !== undefined){
     jQuery.ajaxSetup({
       beforeSend: function (xhr, options){
+        if(options === undefined){
+          return;
+        }
         if(!options.url){
           return;
         }


### PR DESCRIPTION
This fixed an issue on:
 - Plone 4.2
 - Products.PloneArticle 4.2.0
 - collective.js.jqueryui 1.8.16.6
 - plone.app.jquerytools 1.3.2
 - plone.app.jquery 1.4.4

The issue was:
```
Uncaught TypeError: Cannot read property 'url' of undefinedjQuery.ajaxSetup.beforeSend @++resource++protect.js:15
```
