### PR TITLE
Factor out referrer/origin backstop into its own method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 1.0.10 (unreleased)
 -------------------
 
+- Factor out referrer/origin backstop into its own method so it can be
+  customized on a subclassed transform.
+  [lgraf]
+
 - Change extension of CHANGES and README from txt to rst.
   [gforcada]
 

--- a/plone4/csrffixes/transform.py
+++ b/plone4/csrffixes/transform.py
@@ -114,6 +114,16 @@ class Protect4Transform(ProtectTransform):
         except AttributeError:
             return None
 
+    def check_referrer(self, site_url):
+        referrer = self.request.environ.get('HTTP_REFERER')
+        if referrer:
+            if referrer.startswith(site_url + '/'):
+                alsoProvides(self.request, IDisableCSRFProtection)
+        else:
+            origin = self.request.environ.get('HTTP_ORIGIN')
+            if origin and origin == site_url:
+                alsoProvides(self.request, IDisableCSRFProtection)
+
     def transform(self, result, encoding):
 
         site_url = 'foobar'
@@ -150,14 +160,7 @@ class Protect4Transform(ProtectTransform):
 
                 # check referrer/origin header as a backstop to check
                 # against false positives for write on read errors
-                referrer = self.request.environ.get('HTTP_REFERER')
-                if referrer:
-                    if referrer.startswith(site_url + '/'):
-                        alsoProvides(self.request, IDisableCSRFProtection)
-                else:
-                    origin = self.request.environ.get('HTTP_ORIGIN')
-                    if origin and origin == site_url:
-                        alsoProvides(self.request, IDisableCSRFProtection)
+                self.check_referrer(site_url)
 
         result = self.parseTree(result, encoding)
         if result is None:


### PR DESCRIPTION
This is a pure refactoring that extracts the referrer/origin backstop into its own method.

One scenario where this is necessary is the following:

- URL of the Plone site is `https://example.org/`
- There's [CAS Authentication](https://en.wikipedia.org/wiki/Central_Authentication_Service) in play, with the CAS server running at `https://example.org/casportal` (*handled separately from the rest of the URLs in that URL space via an Apache rewrite rule*)
- The CAS server is configured to perform **Single-Sign-On** (e.g. using SPNEGO)

---

- User gets a malicious E-Mail and clicks a link
- Gets redirected to `https://example.org/casportal` by Plone to perform authentication against CAS
- SSO logs the user in automatically, redirects him back to the original URL
- Referrer will be `https://example.org/casportal`, and the request will therefore get whitelisted erroneously

@vangheem 