### PR TITLE
Depend on `plone.protect 3.0.19` or higher.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 1.0.10 (unreleased)
 -------------------
 
+- Depend on ``plone.protect 3.0.19`` or higher.  This adds
+  ``protect.js``, so we do not have to do this anymore.  See issue
+  https://github.com/plone/plone.protect/issues/42
+  [maurits]
+
 - Factor out referrer/origin backstop into its own method so it can be
   customized on a subclassed transform.
   [lgraf]

--- a/plone4/csrffixes/configure.zcml
+++ b/plone4/csrffixes/configure.zcml
@@ -13,11 +13,6 @@
     factory=".transform.Protect4Transform"
     />
 
-  <browser:resource
-    name="protect.js"
-    file="protect.js"
-    />
-
   <monkey:patch
     description=""
     class="Products.CMFPlone.browser.admin.AddPloneSite"

--- a/plone4/csrffixes/transform.py
+++ b/plone4/csrffixes/transform.py
@@ -1,6 +1,5 @@
 from AccessControl import getSecurityManager
 from BTrees.OOBTree import OOBTree
-from lxml import etree
 from plone.app.blob.content import ATBlob
 from plone.keyring.interfaces import IKeyManager
 from plone.protect.authenticator import createToken
@@ -174,21 +173,14 @@ class Protect4Transform(ProtectTransform):
             return
 
         try:
-            token = createToken(manager=self.key_manager)
+            createToken(manager=self.key_manager)
         except ComponentLookupError:
+            # If this fails, then addTokenToUrl will also fail, so it is
+            # useless to try to rewrite links.
             return
 
-        if self.site is not None:
-            body = root.cssselect('body')[0]
-            protect_script = etree.Element("script")
-            protect_script.attrib.update({
-                'type': "application/javascript",
-                'src': "%s/++resource++protect.js" % site_url,
-                'data-site-url': site_url,
-                'data-token': token,
-                'id': 'protect-script'
-            })
-            body.append(protect_script)
+        # Note: we used that add project.js here, but that is handled by
+        # plone.protect 3.0.19 now.
 
         # guess zmi, if it is, rewrite all links
         last_path = self.request.URL.split('/')[-1]

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(name='plone4.csrffixes',
       zip_safe=False,
       install_requires=[
           'setuptools',
-          'plone.protect>=3.0.11',
+          'plone.protect>=3.0.19',
           'plone.keyring>=3.0.1',
           'plone.locking>=2.0.8',
           'collective.monkeypatcher',


### PR DESCRIPTION
This adds `protect.js`, so we do not have to do this anymore.
See issue https://github.com/plone/plone.protect/issues/42

This fixes a zcml conflict when plone.protect 3.0.19 is already there: both packages try to register `protect.js`.